### PR TITLE
Update dockcheck.conf

### DIFF
--- a/dockcheck.conf
+++ b/dockcheck.conf
@@ -1,2 +1,2 @@
-UserParameter=dock.updates,/etc/zabbix/scripts/dockcheck.sh -n | awk '/Containers with updates available:/ {found=1; next} /No updates installed, exiting./ {exit} found && NF {count++} END {print count}'
+UserParameter=dock.updates,/etc/zabbix/scripts/dockcheck.sh -nm | awk '/Containers with updates available:/ {found=1; next} /No updates available, exiting./ {found=0; next} found && NF {count++} END {print count + 0}'
 Timeout=30


### PR DESCRIPTION
1. Added dockcheck option -m (Monochrome mode, no printf colour codes and hides progress bar.)
2. Fixed issue where nothing was reported if no update was found (now prints 0)
3. Dockcheck message changed from "No updates installed, exiting." to "No updates available, exiting."

Dockcheck v0.6.8